### PR TITLE
Readme edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # ECC-for-p256
 This repository is for implementation of ecc, including field arithmetic, point arithemetic, and debug for it. the curve is NIST, the field is p256, parameter a=-3. 
+Now we need to debug ec_twin_mult function.


### PR DESCRIPTION
ec_twin_mult is wrong. The problem may be caused by c array. 